### PR TITLE
Fix GafferDelight builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -247,7 +247,7 @@ if args.project == "gaffer" :
 	# preferred python from the environment. SCons itself
 	# unfortunately hardcodes `/usr/bin/python`, which might not
 	# have the modules we need to build the docs.
-	buildCommand = "python `which scons` package PACKAGE_FILE={uploadFile} ENV_VARS_TO_IMPORT=PATH RMAN_ROOT={delight} ARNOLD_ROOT={arnoldRoot} OPTIONS='' -j {cpus}".format(
+	buildCommand = "python `which scons` package PACKAGE_FILE={uploadFile} ENV_VARS_TO_IMPORT=PATH DELIGHT_ROOT={delight} ARNOLD_ROOT={arnoldRoot} OPTIONS='' -j {cpus}".format(
 		cpus=multiprocessing.cpu_count(), **formatVariables
 	)
 


### PR DESCRIPTION
The build argument changed from RMAN_ROOT to DELIGHT_ROOT back in September 2017, and sadly nobody has noticed since.