### PR TITLE
Dependencies : Update sphinx to version 1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,19 +57,14 @@ RUN yum install -y xkeyboard-config.noarch
 RUN yum install -y fontconfig-devel.x86_64
 
 # Install packages needed to generate the
-# Gaffer documentation. Note that we are
-# limited to Sphinx 1.4 because recommonmark
-# is incompatible with later versions. And
-# we are limited to docutils 0.12 because
-# Sphinx 1.4 is incompatible with later
-# versions.
+# Gaffer documentation.
 
 RUN yum install -y xorg-x11-server-Xvfb
 RUN yum install -y mesa-dri-drivers.x86_64
 RUN yum install -y metacity
 RUN yum install -y gnome-themes-standard
 
-RUN pip install sphinx==1.4 sphinx_rtd_theme recommonmark
+RUN pip install sphinx==1.8 sphinx_rtd_theme recommonmark
 RUN pip install docutils==0.12
 
 RUN yum install -y inkscape


### PR DESCRIPTION
Builds were failing with the following errors. The interwebs suggest
this is related to missing refs. 1.8 properly seems to properly handle
these as errors (along with info on exactly _what_ is missing).

Exception occurred:
  File "/usr/lib/python2.7/site-packages/docutils/nodes.py", line 567, in __getitem__
    return self.attributes[key]
KeyError: 'refdoc