### PR TITLE
build.py : Update installDependencies.sh location

### DIFF
--- a/build.py
+++ b/build.py
@@ -306,7 +306,11 @@ os.chdir( sourceDirName )
 # against the same dependencies we have tested against.
 
 if args.project == "gaffer" :
-	subprocess.check_call( "./config/travis/installDependencies.sh", shell = True )
+	# The scripts moved in #3242
+	depsInstallScript = "./config/installDependencies.sh"
+	if not os.path.exists( os.path.join( os.getcwd(), depsInstallScript ) ) :
+		depsInstallScript = "./config/travis/installDependencies.sh"
+	subprocess.check_call( depsInstallScript, shell = True )
 
 # Perform the build.
 


### PR DESCRIPTION
This moved in gaffer#3242, `build.py` now supports old and new locations.