### PR TITLE
build.py : Bump image version

### DIFF
--- a/build.py
+++ b/build.py
@@ -50,7 +50,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument(
 	"--build-env-version",
 	dest = "buildEnvVersion",
-	default = "1.0.0",
+	default = "1.1.0",
 	help = "The container image tag to use for docker builds."
 )
 


### PR DESCRIPTION
I _think_ we want to merge this before we we release? So that tag builds with itself? A bit meta? Otherwise the `1.1.0` tag would still use `1.0.0`. There will be the witching hour before CI has made the image where builds would fail (note: doesn't affect Azure, just builds with `build.py`).