### PR TITLE
build.py : Revert to DockerHub hosted images

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,7 +57,7 @@ parser.add_argument(
 parser.add_argument(
 	"--build-env-image",
 	dest = "buildEnvImage",
-	default = "docker.pkg.github.com/gafferhq/build/build",
+	default = "gafferhq/build",
 	help = "The container image to use for docker builds."
 )
 


### PR DESCRIPTION
Due to the current auth requirements of GitHub Packages:

  https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782