### PR TITLE
build.py --resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Make a Linux release using Docker on a Mac :
 
 `./build.py --docker 1 --arnoldRoot /path/to/linux/arnoldRoot --delightRoot /path/to/linux/delightRoot --version 0.45.0.0 --upload 1`
 
+At times, builds may fail for assorted reasons. In such cases, the `-resume 1` argument can be used to attempt to continue making use of any existing build artifacts. Without this flag, the each build will start with a clean source tree/container.
+
 Steps remaining to be automated
 -------------------------------
 

--- a/build.py
+++ b/build.py
@@ -130,6 +130,13 @@ parser.add_argument(
 		   "performing the build. This is useful for debugging."
 )
 
+parser.add_argument(
+	"--resume",
+	type = distutils.util.strtobool,
+	default = "0",
+	help = "Allows non-container builds to reuse an existing build in the case of previous errors."
+)
+
 args = parser.parse_args()
 
 if args.interactive :
@@ -313,8 +320,10 @@ subprocess.check_call( downloadCommand, shell = True )
 
 sys.stderr.write( "Decompressing source to \"%s\"\n" % sourceDirName )
 
-shutil.rmtree( sourceDirName, ignore_errors = True )
-os.makedirs( sourceDirName )
+if not args.resume :
+	shutil.rmtree( sourceDirName, ignore_errors = True )
+if not os.path.exists( sourceDirName ) :
+	os.makedirs( sourceDirName )
 subprocess.check_call( "tar xf %s -C %s --strip-components=1" % ( tarFileName, sourceDirName ), shell = True )
 os.chdir( sourceDirName )
 


### PR DESCRIPTION
`build.py` used to obliterate the checkout each time. This could loose a lot of time in the case of a failed download, etc. This adds experimental `--resume` support, that attempts to re-use an existing checkout/build, thanks to the lovely work John did in https://github.com/GafferHQ/dependencies/pull/136.

Aside from resume, it should also stop us proliferating images if you repeatedly run `build` on the same machine.

NOTE: Have occasionally seen some issues in docker containers where forcibly killing the build command (rather than having it fail) can leave the container file system in an 'interesting' state, that throws all sorts of errors (eg: can't access `<source>/build.py`, even though its definitely there. In this cause, just don't use `--resume 1`. Self-failures that cause an exit seem less problematic though, so it feels like this still has some utility regardless, especially with flaky downloads.

PS. The mixture of shelling out to docker vs the SDK is comical to say the least, but it avoids ~10x the amount of code to copy each way via the SDK.
