### PR TITLE
Dockerfile : Set `WORKDIR` to `/`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+3.0.0ax
+=======
+
+- Dockerfile :
+  - Set `WORKDIR` to `/`.
+
 3.0.0a1
 =======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,11 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # correct version will already be installed and we just ignore this...
 	./versionlock.sh lock-new /tmp/packages
 
+# Set WORKDIR back to / to match the behaviour of our CentOS 7 Dockerfile.
+# This makes it easier to deal with copying build artifacts as they will be
+# in the same location in both containers.
+WORKDIR /
+
 # ci-base sets PYTHONPATH, so we override it back to nothing for our env
 ENV PYTHONPATH=
 #


### PR DESCRIPTION
Our CentOS 7 Dockerfile doesn't define [WORKDIR](https://docs.docker.com/engine/reference/builder/#workdir) so it defaults to `/`. The `aswf/ci-common` Dockerfile sets `WORKDIR` to `/opt/aswf`, so we need to override it back to `/`in oder to match the behaviour of our previous container. Otherwise builds are produced under `/opt/aswf` on Rocky 8 and `/` on CentOS 7, which is problematic when trying to reliably copy build artifacts from each container...