### PR TITLE
Add Python `sqlite3` and `ssl` module dependencies

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+2.x.x
+=====
+
+- Dockerfile :
+  - Added `sqlite-devel` package necessary for building Python with `sqlite3` support.
+  - Added `openssl-devel` and `openssl11-devel` packages necessary for building Python with support for OpenSSL 1.1.1.
+
 2.0.0
 =====
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 - Dockerfile :
   - Added `sqlite-devel` package necessary for building Python with `sqlite3` support.
   - Added `openssl-devel` and `openssl11-devel` packages necessary for building Python with support for OpenSSL 1.1.1.
+  - Updated SCons to 4.6.0.
 
 2.0.0
 =====

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,13 @@ RUN yum install -y yum-versionlock && \
 	yum install -y \
 		lz4 lz4-devel && \
 #
+#	Install Python dependencies (needed for Python ssl and sqlite3 modules)
+#
+	yum install -y \
+		openssl-devel \
+		openssl11-devel \
+		sqlite-devel && \
+#
 # Install packages needed to generate the
 # Gaffer documentation.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN yum install -y yum-versionlock && \
 	yum install -y cmake3 && \
 	ln -s /usr/bin/cmake3 /usr/bin/cmake && \
 #
-	pip install scons==3.1.2 && \
+	pip install scons==4.6.0 && \
 #
 	yum install -y \
 		git \

--- a/yum-versionlock.list
+++ b/yum-versionlock.list
@@ -76,8 +76,8 @@
 0:gettext-0.19.8.1-3.el7.*
 0:gettext-libs-0.19.8.1-3.el7.*
 0:git-1.8.3.1-23.el7_8.*
-0:glibc-devel-2.17-325.el7_9.*
-0:glibc-headers-2.17-325.el7_9.*
+0:glibc-devel-2.17-326.el7_9.*
+0:glibc-headers-2.17-326.el7_9.*
 0:glibmm24-2.56.0-1.el7.*
 0:glib-networking-2.56.1-1.el7.*
 0:gl-manpages-1.1-7.20130122.el7.*
@@ -108,7 +108,10 @@
 0:jbigkit-libs-2.0-11.el7.*
 0:json-glib-1.4.2-2.el7.*
 0:kernel-debug-devel-3.10.0-1160.49.1.el7.*
+0:kernel-devel-3.10.0-1160.105.1.el7.*
 0:kernel-headers-3.10.0-1160.49.1.el7.*
+0:keyutils-libs-devel-1.5.8-3.el7.*
+0:krb5-devel-1.15.1-55.el7_9.*
 0:lapack-3.4.2-8.el7.*
 0:lcms2-2.6-3.el7.*
 0:less-458-9.el7.*
@@ -117,6 +120,7 @@
 0:libcanberra-gtk2-0.30-9.el7.*
 0:libcanberra-gtk3-0.30-9.el7.*
 0:libcgroup-0.41-21.el7.*
+0:libcom_err-devel-1.42.9-19.el7.*
 0:libcroco-0.6.12-6.el7_9.*
 0:libdrm-2.4.97-2.el7.*
 0:libdrm-devel-2.4.97-2.el7.*
@@ -132,6 +136,7 @@
 0:libICE-devel-1.0.9-9.el7.*
 0:libicu-50.2-4.el7_7.*
 0:libjpeg-turbo-1.2.90-8.el7.*
+0:libkadm5-1.15.1-55.el7_9.*
 0:libmodman-2.0.1-8.el7.*
 0:libmpc-1.0.1-3.el7.*
 0:libnotify-0.7.7-1.el7.*
@@ -141,9 +146,11 @@
 0:libquadmath-4.8.5-44.el7.*
 0:librevenge-0.0.2-2.el7.*
 0:librsvg2-2.40.20-1.el7.*
+0:libselinux-devel-2.5-15.el7.*
 0:libselinux-python-2.5-15.el7.*
 0:libselinux-utils-2.5-15.el7.*
 0:libsemanage-python-2.5-14.el7.*
+0:libsepol-devel-2.5-10.el7.*
 0:libsigc++20-2.10.0-1.el7.*
 0:libSM-1.2.2-2.el7.*
 0:libSM-devel-1.2.2-2.el7.*
@@ -157,6 +164,7 @@
 0:libunistring-0.9.3-9.el7.*
 0:libusbx-1.0.21-1.el7.*
 0:libuuid-devel-2.23.2-65.el7_9.1.*
+0:libverto-devel-0.2.5-4.el7.*
 0:libwayland-client-1.15.0-1.el7.*
 0:libwayland-cursor-1.15.0-1.el7.*
 0:libwayland-egl-1.15.0-1.el7.*
@@ -202,7 +210,7 @@
 0:libXxf86misc-1.0.3-7.1.el7.*
 0:libXxf86vm-1.1.4-1.el7.*
 0:libXxf86vm-devel-1.1.4-1.el7.*
-0:libzstd-1.5.0-1.el7.*
+0:libzstd-1.5.5-1.el7.*
 0:llvm-private-7.0.1-1.el7.*
 0:lz4-devel-1.8.3-1.el7.*
 0:m4-1.4.16-10.el7.*
@@ -229,6 +237,7 @@
 0:pango-1.42.4-4.el7_7.*
 0:pangomm-2.40.1-1.el7.*
 0:patch-2.7.1-12.el7_7.*
+0:pcre-devel-8.32-17.el7.*
 0:perl-Carp-1.26-244.el7.*
 0:perl-constant-1.27-2.el7.*
 0:perl-Encode-2.51-7.el7.*
@@ -284,6 +293,7 @@
 0:setools-libs-3.3.8-4.el7.*
 0:sound-theme-freedesktop-0.8-3.el7.*
 0:source-highlight-3.1.6-6.el7.*
+0:sqlite-devel-3.7.17-8.el7_7.1.*
 0:startup-notification-0.12-8.el7.*
 0:tcp_wrappers-libs-7.6-77.el7.*
 0:trousers-0.3.14-2.el7.*
@@ -334,10 +344,13 @@
 1:libglvnd-gles-1.0.1-0.8.git5baa1e5.el7.*
 1:libglvnd-glx-1.0.1-0.8.git5baa1e5.el7.*
 1:libglvnd-opengl-1.0.1-0.8.git5baa1e5.el7.*
-1:libuv-1.42.0-2.el7.*
+1:libuv-1.44.2-1.el7.*
 1:libvorbis-1.3.3-8.el7.1.*
 1:make-3.82-24.el7.*
 1:numpy-1.7.1-13.el7.*
+1:openssl11-devel-1.1.1k-6.el7.*
+1:openssl11-libs-1.1.1k-6.el7.*
+1:openssl-devel-1.0.2k-26.el7_9.*
 1:perl-Error-0.17020-2.el7.*
 1:perl-parent-0.225-244.el7.*
 1:perl-Pod-Escapes-1.04-299.el7_9.*
@@ -351,4 +364,4 @@
 4:perl-libs-5.16.3-299.el7_9.*
 4:perl-macros-5.16.3-299.el7_9.*
 4:perl-Time-HiRes-1.9725-3.el7.*
-# Added locks on Thu Dec  9 09:43:43 2021
+# Added locks on Thu Jan 11 20:25:15 2024


### PR DESCRIPTION
This contains a few updates the 2.x build container in preparation for a new container release to be used for the GCC 9 builds of Gaffer 1.4. 

We now install the `sqlite-devel` package necessary for building Python with `sqlite3` module support. This was requested in https://github.com/GafferHQ/gaffer/issues/5457.

We also install the `openssl-devel` and `openssl11-devel` packages necessary for building Python with `ssl` module support. We're doing this here in an attempt to avoid including OpenSSL in Gaffer's dependencies in order to stop distributing OpenSSL with Gaffer itself. `openssl11-devel` is included so we can build Python against OpenSSL 1.1.1 rather than the CentOS 7 default of 1.0.2.

I've also taken the liberty of updating SCons to 4.6.0 to match the current version in the 3.x build container used for the GCC 11 builds of Gaffer, so we're not using two different SCons versions for the Gaffer 1.4 Linux builds.