### PR TITLE
Dockerfile : Update to CMake 3.27.2

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
   - Added `sqlite-devel` package necessary for building Python with `sqlite3` support.
   - Added `openssl-devel` and `openssl11-devel` packages necessary for building Python with support for OpenSSL 1.1.1.
   - Updated SCons to 4.6.0.
+  - Updated CMake to 3.27.2.
 
 2.0.0
 =====

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ RUN yum install -y yum-versionlock && \
 #
 	yum install -y epel-release && \
 #
-	yum install -y cmake3 && \
-	ln -s /usr/bin/cmake3 /usr/bin/cmake && \
+	curl -L "https://github.com/Kitware/CMake/releases/download/v3.27.2/cmake-3.27.2-Linux-x86_64.sh" -o /tmp/cmake-3.27.2-Linux-x86_64.sh && \
+	sh /tmp/cmake-3.27.2-Linux-x86_64.sh --skip-license --prefix=/usr/local --exclude-subdir && \
+	rm /tmp/cmake-3.27.2-Linux-x86_64.sh && \
 #
 	pip install scons==4.6.0 && \
 #

--- a/yum-versionlock.list
+++ b/yum-versionlock.list
@@ -25,8 +25,6 @@
 0:centos-release-scl-2-3.el7.centos.*
 0:centos-release-scl-rh-2-3.el7.centos.*
 0:checkpolicy-2.5-8.el7.*
-0:cmake3-3.17.5-1.el7.*
-0:cmake3-data-3.17.5-1.el7.*
 0:colord-libs-1.3.4-2.el7.*
 0:cpp-4.8.5-44.el7.*
 0:ctags-5.8-13.el7.*


### PR DESCRIPTION
OpenVDB 10 requires CMake 3.18 or higher. CMake 3.17.5 is the highest version available via yum, so we need to manually install a newer version. CMake 3.27.2 is used in the new `3.x` build environment, so for consistency we use the same version here.