### PR TITLE
Dockerfile : Make `openssl11` discoverable by Python

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+2.x.x
+=====
+
+- Dockerfile :
+  - Removed `openssl-devel` package.
+  - Symlinked `openssl11-devel` headers and libraries into `/usr/local/ssl` so they can be automatically found when building Python.
+
 2.1.1
 =====
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,14 @@ RUN yum install -y yum-versionlock && \
 #	Install Python dependencies (needed for Python ssl and sqlite3 modules)
 #
 	yum install -y \
-		openssl-devel \
 		openssl11-devel \
 		sqlite-devel && \
+#
+#	Symlink openssl11 libs and headers to a location where Python's `configure` script can find them
+#
+	mkdir /usr/local/ssl && \
+	ln -s /usr/lib64/openssl11 /usr/local/ssl/lib && \
+	ln -s /usr/include/openssl11 /usr/local/ssl/include && \
 #
 # Install packages needed to generate the
 # Gaffer documentation.

--- a/yum-versionlock.list
+++ b/yum-versionlock.list
@@ -346,9 +346,8 @@
 1:libvorbis-1.3.3-8.el7.1.*
 1:make-3.82-24.el7.*
 1:numpy-1.7.1-13.el7.*
-1:openssl11-devel-1.1.1k-6.el7.*
-1:openssl11-libs-1.1.1k-6.el7.*
-1:openssl-devel-1.0.2k-26.el7_9.*
+1:openssl11-devel-1.1.1k-7.el7.*
+1:openssl11-libs-1.1.1k-7.el7.*
 1:perl-Error-0.17020-2.el7.*
 1:perl-parent-0.225-244.el7.*
 1:perl-Pod-Escapes-1.04-299.el7_9.*


### PR DESCRIPTION
Python's `configure` script looks for OpenSSL in a variety of fallback paths if it can't find it via `pkg-config`. `openssl11-devel` doesn't install to any of these paths, and doesn't install libs and headers under a common root suitable for configure's `--with-openssl` flag, so we symlink into the first of the fallback paths.

We remove `openssl-devel` to prevent Python from finding it via `pkg-config`. This is of no use as Python 3.10 dropped support for OpenSSL 1.0 and prevents the above discovery of `openssl11-devel`.