### PR TITLE
Podman container

### DIFF
--- a/.github/workflows/dockerImagePublish.yml
+++ b/.github/workflows/dockerImagePublish.yml
@@ -38,11 +38,11 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag image
+    - name: Build the container image
+      run: podman build . --file Dockerfile --tag image --squash-all
 
     - name: Log into registry
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
     - name: Push image
       run: |
@@ -54,5 +54,5 @@ jobs:
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
 
-        docker tag image $IMAGE_ID:$VERSION
-        docker push $IMAGE_ID:$VERSION
+        podman tag image $IMAGE_ID:$VERSION
+        podman push $IMAGE_ID:$VERSION

--- a/.github/workflows/dockerImagePublish.yml
+++ b/.github/workflows/dockerImagePublish.yml
@@ -36,7 +36,7 @@ jobs:
         echo "Package cleanup: "
         df -h /
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build the container image
       run: podman build . --file Dockerfile --tag image --squash-all

--- a/.github/workflows/dockerImagePublish.yml
+++ b/.github/workflows/dockerImagePublish.yml
@@ -14,6 +14,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Free additional disk space
+      run: |
+        echo "Initial free space: "
+        df -h /
+        sudo rm -rf /usr/local/lib/android
+        echo "Removed Android SDK: "
+        df -h /
+        sudo rm -rf /usr/share/dotnet
+        echo "Removed .NET runtime: "
+        df -h /
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        echo "Tool cache cleanup: "
+        df -h /
+        sudo docker image prune --all --force
+        echo "Docker prune: "
+        df -h /
+        sudo apt remove -y '^llvm-.*-dev$' '^dotnet-.*' '^openjdk-.*' '.*-jdk$' firefox google-chrome-stable microsoft-edge-stable google-cloud-cli azure-cli mono-devel powershell
+        sudo apt autoremove -y
+        sudo apt clean
+        echo "Package cleanup: "
+        df -h /
+
     - uses: actions/checkout@v2
 
     - name: Build the Docker image

--- a/.github/workflows/dockerImagePublish.yml
+++ b/.github/workflows/dockerImagePublish.yml
@@ -42,12 +42,12 @@ jobs:
       run: podman build . --file Dockerfile --tag image --squash-all
 
     - name: Log into registry
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: Push image
       run: |
         # Image ID must be lowercase
-        IMAGE_ID=docker.pkg.github.com/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')/$IMAGE_NAME
+        IMAGE_ID=ghcr.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')/$IMAGE_NAME
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,9 @@
 =======
 
 - Dockerfile : Removed `cuda-nsight-compute-11-8.x86_64`, `libcublas-devel-11-8-11.11.3.6-1.x86_64`, `sonar-scanner-4.8.0.2856-linux`, and various intermediate installation files to reduce container size.
+- CI :
+  - Container image is now built with `podman` rather than `docker`.
+  - Container image is built with `--squash-all` in order to reduce overall container size.
 
 3.0.0a5
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 - CI :
   - Container image is now built with `podman` rather than `docker`.
   - Container image is built with `--squash-all` in order to reduce overall container size.
+  - References to `docker.pkg.github.com` have been changed to `ghcr.io`.
 
 3.0.0a5
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+3.0.0ax
+=======
+
+- Dockerfile : Removed `cuda-nsight-compute-11-8.x86_64`, `libcublas-devel-11-8-11.11.3.6-1.x86_64`, `sonar-scanner-4.8.0.2856-linux`, and various intermediate installation files to reduce container size.
+
 3.0.0a5
 =======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,17 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 	ln -s /opt/inkscape-1.3.2/squashfs-root/AppRun /usr/local/bin/inkscape && \
 	cd - && \
 #
+# Trim out a few things we don't need. We inherited a lot more than we need from
+# `aswf/ci-base`, and we run out of disk space on GitHub Actions if our container
+# is too big. A particular offender is CUDA, which comes with all sorts of
+# bells and whistles we don't need, and is responsible for at least 5Gb of the
+# total image size.
+	rm -rf /var/opt/sonar-scanner-4.8.0.2856-linux && \
+	dnf remove -y \
+		cuda-nsight-compute-11-8.x86_64 \
+		libcublas-devel-11-8-11.11.3.6-1.x86_64 && \
+	dnf clean all && \
+#
 # Now we've installed all our packages, update yum-versionlock for all the
 # new packages so we can copy the versionlock.list out of the container when we
 # want to update the build env.

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 	chmod a+x Inkscape-091e20e-x86_64.AppImage && \
 	./Inkscape-091e20e-x86_64.AppImage --appimage-extract && \
 	ln -s /opt/inkscape-1.3.2/squashfs-root/AppRun /usr/local/bin/inkscape && \
+	rm -f Inkscape-091e20e-x86_64.AppImage && \
 	cd - && \
 #
 # Trim out a few things we don't need. We inherited a lot more than we need from
@@ -73,6 +74,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # bells and whistles we don't need, and is responsible for at least 5Gb of the
 # total image size.
 	rm -rf /var/opt/sonar-scanner-4.8.0.2856-linux && \
+	rm -rf /tmp/downloads && \
 	dnf remove -y \
 		cuda-nsight-compute-11-8.x86_64 \
 		libcublas-devel-11-8-11.11.3.6-1.x86_64 && \


### PR DESCRIPTION
The new `gcc11` container has been causing trouble on CI simply due to its size. Slimming down this container has been challenging due to most of the weight coming from files in layers that Docker wouldn't allow us to modify. As such, we've switched to a podman built container that allows us to use the `--squash-all` flag to squash our edits to upstream layers into a single monolithic image, which allows deletions from those upstream layers to reflect in an overall reduction in container size.

Building this monolithic image does require quite a lot of available disk space, more than a regular actions runner has available. So we remove a large amount of unnecessary software installed on the runner before building the container.