### PR TITLE
Prep 3.0.0 final release

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,43 +1,10 @@
-3.0.0ax
-=======
+3.0.0
+=====
 
-- Dockerfile : Removed `libcublas-11-8`, `libnccl`, `libnccl-devel`, `libnpp-11-8`, `libnpp-devel-11-8`, `cuda-cupti-11-8`, and local installations of LLVM and Boost to reduce container size.
-
-3.0.0a6
-=======
-
-- Dockerfile : Removed `cuda-nsight-compute-11-8.x86_64`, `libcublas-devel-11-8-11.11.3.6-1.x86_64`, `sonar-scanner-4.8.0.2856-linux`, and various intermediate installation files to reduce container size.
 - CI :
   - Container image is now built with `podman` rather than `docker`.
   - Container image is built with `--squash-all` in order to reduce overall container size.
   - References to `docker.pkg.github.com` have been changed to `ghcr.io`.
-
-3.0.0a5
-=======
-
-- Dockerfile : Set `OPTIX_ROOT_DIR` environment variable.
-
-3.0.0a4
-=======
-
-- Dockerfile :
-  - Fixed `sphinx` incompatibility with automatically installed dependencies by installing specific versions of `sphinxcontrib` packages.
-
-3.0.0a3
-=======
-
-- Dockerfile :
-  - Added `GAFFER_BUILD_ENVIRONMENT="gcc11"` environment variable.
-
-3.0.0a2
-=======
-
-- Dockerfile :
-  - Set `WORKDIR` to `/`.
-
-3.0.0a1
-=======
-
 - Dockerfile :
   - Changed base image to `aswf/ci-base:2023.2`, changes from this image include :
     - Builds are now performed on Rocky 8.8 with glibc 2.28.
@@ -55,6 +22,12 @@
   - Removed installation of `lz4` and `lz4-devel` as we no longer build Appleseed.
   - Updated `inkscape` to 1.3.2.
   - Updated `scons` to 4.6.0.
+  - Set `WORKDIR` to `/`.
+  - Set `OPTIX_ROOT_DIR` environment variable.
+  - Added `GAFFER_BUILD_ENVIRONMENT="gcc11"` environment variable.
+  - Fixed `sphinx` incompatibility with automatically installed dependencies by installing specific versions of `sphinxcontrib` packages.
+  - Removed unnecessary packages provided by the `ci-base` image to reduce container size :
+    - `cuda-nsight-compute-11-8.x86_64`, `libcublas-devel-11-8-11.11.3.6-1.x86_64`, `sonar-scanner-4.8.0.2856-linux`, `libcublas-11-8`, `libnccl`, `libnccl-devel`, `libnpp-11-8`, `libnpp-devel-11-8`, `cuda-cupti-11-8` and various intermediate installation files.
 
 2.1.1
 =====

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+3.0.0ax
+=======
+
+- Dockerfile : Removed `libcublas-11-8`, `libnccl`, `libnccl-devel`, `libnpp-11-8`, `libnpp-devel-11-8`, `cuda-cupti-11-8`, and local installations of LLVM and Boost to reduce container size.
+
 3.0.0a6
 =======
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,12 +72,26 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # `aswf/ci-base`, and we run out of disk space on GitHub Actions if our container
 # is too big. A particular offender is CUDA, which comes with all sorts of
 # bells and whistles we don't need, and is responsible for at least 5Gb of the
-# total image size.
+# total image size. We also remove much of the `ci-base` provided builds of LLVM
+# and Boost. Removing these plus some additional CUDA packages brings the image
+# size down to ~3.6GB.
+	rm -rf /usr/local/lib/clang && \
+	rm -f /usr/local/lib/libclang* && \
+	rm -f /usr/local/lib/libLLVM* && \
+	rm -f /usr/local/lib/libLTO* && \
+	rm -f /usr/local/lib/liblld* && \
+	rm -f /usr/local/lib/libboost* && \
+	rm -f /usr/local/bin/clang* && \
+	rm -f /usr/local/bin/ll* && \
+	rm -f /usr/local/bin/opt && \
+	rm -f /usr/local/bin/bugpoint && \
 	rm -rf /var/opt/sonar-scanner-4.8.0.2856-linux && \
 	rm -rf /tmp/downloads && \
 	dnf remove -y \
 		cuda-nsight-compute-11-8.x86_64 \
-		libcublas-devel-11-8-11.11.3.6-1.x86_64 && \
+		libcublas-devel-11-8-11.11.3.6-1.x86_64 \
+		libcublas-11-8 libnccl libnccl-devel \
+		libnpp-11-8 libnpp-devel-11-8 cuda-cupti-11-8 && \
 	dnf clean all && \
 #
 # Now we've installed all our packages, update yum-versionlock for all the

--- a/build.py
+++ b/build.py
@@ -118,7 +118,7 @@ parser.add_argument(
 parser.add_argument(
 	"--docker-image-version",
 	dest = "dockerImageVersion",
-	default = "3.0.0a6",
+	default = "3.0.0",
 	help = "The Docker image tag to use for Docker builds."
 )
 


### PR DESCRIPTION
Prep for a final 3.0.0 container release, with some additional package removal and cleanup to bring the overall container size down to ~3.6GB.