### PR TITLE
build.py : Allow `--arnoldRoot` to be specified multiple times

### DIFF
--- a/build.py
+++ b/build.py
@@ -351,7 +351,7 @@ if args.project == "gaffer" :
 
 else :
 
-	buildCommand = "env RMAN_ROOT={delight} ARNOLD_ROOT={arnoldRoot} ./build.py --buildDir {cwd}/{buildName} --package {cwd}/{buildName}.tar.gz".format(
+	buildCommand = "./build.py --buildDir {cwd}/{buildName} --package {cwd}/{buildName}.tar.gz".format(
 		cwd = os.getcwd(),
 		**formatVariables
 	)

--- a/build.py
+++ b/build.py
@@ -209,7 +209,7 @@ if githubToken :
 	formatVariables[ "auth" ] = '-H "Authorization: token %s"' % githubToken
 
 if args.project == "gaffer" :
-	formatVariables["buildName"] = "{project}-{version}-{platform}".format( **formatVariables )
+	formatVariables["buildName"] = "{project}-{version}-{platform}{buildEnvironment}".format( **formatVariables )
 else :
 	formatVariables["buildName"] = "gafferDependencies-{version}-{platform}{buildEnvironment}".format( **formatVariables )
 


### PR DESCRIPTION
This gets us in to a position where we can use `build.py` to make official release builds again, should GitHub Actions be unavailable. It's particularly relevant for 1.4.x releases since GitHub Actions is no longer compatible with the CentOS build containers we need for the GCC 9 variant.