### PR TITLE
Add libraries needed by RenderMan

### DIFF
--- a/.github/workflows/dockerImagePublish.yml
+++ b/.github/workflows/dockerImagePublish.yml
@@ -1,4 +1,4 @@
-name: Docker Image Publish
+name: Container Publish
 
 on:
   release:
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build the container image
-      run: podman build . --file Dockerfile --tag image --squash-all
+      run: podman build . --file Containerfile --tag image --squash-all
 
     - name: Log into registry
       run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 3.x.x
 =====
 
+
+
+3.2.0
+=====
+
 - Dockerfile :
   - Renamed to Containerfile, since we no longer use Docker.
   - Added libraries needed by RenderMan.

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+3.x.x
+=====
+
+- Dockerfile : Renamed to Containerfile, since we no longer use Docker.
+- `build-docker.py` :
+  - Reimplemented using `podman`.
+  - Renamed to `build-container.py`, since we no longer use Docker.
+
 3.1.0
 =====
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 3.x.x
 =====
 
-- Dockerfile : Renamed to Containerfile, since we no longer use Docker.
+- Dockerfile :
+  - Renamed to Containerfile, since we no longer use Docker.
+  - Added libraries needed by RenderMan.
 - `build-docker.py` :
   - Reimplemented using `podman`.
   - Renamed to `build-container.py`, since we no longer use Docker.

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,7 @@ ENV GAFFER_BUILD_ENVIRONMENT="gcc11"
 # As we don't want to inadvertently grab newer versions of our yum-installed
 # packages, we use yum-versionlock to keep them pinned. We track the list of
 # image packages here, then compare after our install steps to see what was
-# added, and only lock those. This saves us storing redundant entires for
+# added, and only lock those. This saves us storing redundant entries for
 # packages installed in the base image.
 
 # To unlock versions, just make sure yum-versionlock.list is empty in the repo
@@ -71,6 +71,10 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # Install meson as it is needed to build LibEpoxy if building Cycles with USD support.
 #
 	pip install meson && \
+#
+# Install libraries needed by RenderMan.
+#
+	dnf install -y ncurses-compat-libs && \
 #
 # Trim out a few things we don't need. We inherited a lot more than we need from
 # `aswf/ci-base`, and we run out of disk space on GitHub Actions if our container

--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # NOTE: If you add a new yum package here, make sure you update the version
 # lock files as follows and commit the changes to yum-versionlock.list:
 #
-#   ./build-docker.py --update-version-locks --new-only
+#   ./build-container.py --update-version-locks --new-only
 #
 #	We install SCons via `pip install` rather than by
 #	`yum install` because this prevents a Cortex build failure
@@ -57,8 +57,8 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 		docutils==0.17.1 && \
 #
 # Install Inkscape 1.3.2
-# Inkscape is distrubuted as an AppImage. AppImages seemingly can't be run (easily?) under
-# Docker as they require FUSE, so we extract the image so its contents can be run directly.
+# Inkscape is distributed as an AppImage. AppImages seemingly can't be run (easily?) in a
+# container as they require FUSE, so we extract the image so its contents can be run directly.
 	mkdir /opt/inkscape-1.3.2 && \
 	cd /opt/inkscape-1.3.2 && \
 	curl -O https://media.inkscape.org/dl/resources/file/Inkscape-091e20e-x86_64.AppImage && \
@@ -114,7 +114,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # the versionlock list also populates the cache, so this cleanup is best run last.
 	dnf clean all
 
-# Set WORKDIR back to / to match the behaviour of our CentOS 7 Dockerfile.
+# Set WORKDIR back to / to match the behaviour of our CentOS 7 container.
 # This makes it easier to deal with copying build artifacts as they will be
 # in the same location in both containers.
 WORKDIR /

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prerequisites
 
 - ARNOLD_ROOT environment variable pointing to installation of Arnold 7.1 or later
 - DELIGHT environment variable pointing to installation of 3delight NSI 2.x
-- Docker 17.05 or later
+- Podman.
 
 Usage
 -----
@@ -27,38 +27,38 @@ Make a Linux release using a container on a Mac :
 
 `./build.py --container 1 --arnoldRoot /path/to/linux/arnoldRoot --delightRoot /path/to/linux/delightRoot --version 1.4.0.0 --upload 1`
 
-Docker Cheatsheet
+Podman Cheatsheet
 -----------------
 
 Remove stopped containers and dangling images :
 
-`docker system prune`
+`podman system prune`
 
 Remove all images, not just temporary container images :
 
-`docker system prune -a`
+`podman system prune -a`
 
 Debug a stopped build container :
 
 ```
 # Find the container of interest
-docker ps -a
+podman ps -a
 # Make a new image from container
-docker commit <containerID> <imageName>
+podman commit <containerID> <imageName>
 # Run interactive session in new image
-docker run -it <imageName> /bin/bash
+podman run -it <imageName> /bin/bash
 ```
 
 Building the build environment
 ------------------------------
 
-Gaffer and Dependency builds are made using pre-published Docker images. These
-images are built from the Dockerfile in this repository. The `build-docker.py`
+Gaffer and Dependency builds are made using pre-published container images. These
+images are built from the Containerfile in this repository. The `build-container.py`
 script aids the building of the images. For example :
 
- `./build-docker.py --tag 1.1.0`
+ `./build-container.py --tag 1.1.0`
 
-> NOTE: The `build-docker.py` uses the simpler flag syntax for most of it options,
+> NOTE: The `build-container.py` uses the simpler flag syntax for most of it options,
 > this means its a little different to `build.py`, we aim to update that over
 > time to match.
 
@@ -73,38 +73,38 @@ to aid updating of the lock list when new packages are added or updates are requ
 
  - `--update-version-locks` When set this will ignore all version locks and
    update `yum-versionlock.list` to the 'current' version of all packages
-   installed during docker's build. The revised file can then be committed and tagged,
-   and a new docker image released.
+   installed during the container build. The revised file can then be committed and tagged,
+   and a new image released.
 
  - `--new-only` When set the existing version lock list will not be cleared.
    This allows the versions to be locked for any new packages installed by
-   changes to the `Dockerfile` without affecting the versions of existing
+   changes to the `Containerfile` without affecting the versions of existing
    packages.
 
 ### Cheat sheet
 
-Added a new package to the image, installed with yum in the Dockerfile:
+Added a new package to the image, installed with yum in the Containerfile:
 
-`./build-docker.py --update-version-locks --new-only --tag x.x.x`
+`./build-container.py --update-version-locks --new-only --tag x.x.x`
 
 Update all packages to latest:
 
-`./build-docker.py --update-version-locks --tag x.x.x`
+`./build-container.py --update-version-locks --tag x.x.x`
 
 ### Releasing a new version of the build environment
 
-Docker images are automatically published to the GitHub Container Registry
+Container images are automatically published to the GitHub Container Registry
 whenever a new release is made via https://github.com/GafferHQ/build/releases.
-This is performed by the `.github/workflows/dockerImagePublish.yml` workflow.
+This is performed by the `.github/workflows/containerImagePublish.yml` workflow.
 Once published, the images can be used by `./build.py` and by the CI process
 for `GafferHQ/gaffer`.
 
-### A note on Docker's caching mechanism
+### A note on Podman's caching mechanism
 
-Docker caches layers based on the `RUN` command string. As such, it does not
+Podman caches layers based on the `RUN` command string. As such, it does not
 known when the version lock file changes. the `--update-version-locks` command
 will always run with `--no-cache` set, but if you've just pulled some updates
-from upstream, and are re-building on your machine, you may find docker will
+from upstream, and are re-building on your machine, you may find podman will
 be using an out-of-date cache of one or more of the layers.
 
 As such, its recommended to use `--no-cache` whenever performing release

--- a/build-container.py
+++ b/build-container.py
@@ -53,7 +53,7 @@ parser = argparse.ArgumentParser(
 	    "The yum version locking mechanism works as follows:\n"
 	    " 1. The source checkout contains a yum-versionlock formatted list of\n"
 	    "    package versions.\n"
-	    " 2. The Dockerfile copies this in at the beginning of a build. \n"
+	    " 2. The Containerfile copies this in at the beginning of a build. \n"
 	    " 3. Any yum installs during the build will then respect these versions.\n"
 	    " 4. At the end of the build, if requested, we update the file with the\n"
 	    "    versions of any new (or optionally - all) packages.\n"
@@ -66,20 +66,20 @@ parser.add_argument(
 	"--tag",
 	dest = "tag",
 	default = "latest",
-	help = "The tag to apply to the build docker image when building the 'build' project."
+	help = "The tag to apply to the built image when building the 'build' project."
 )
 
 parser.add_argument(
 	"--image",
 	default = "gafferhq/build",
-	help = "The dockerhub organisation and image name to use in the image tag."
+	help = "The organisation and image name to use in the image tag."
 )
 
 parser.add_argument(
 	"--no-cache",
 	dest = "noCache",
 	action = 'store_true',
-	help = "Because docker caches layers based on the RUN command string it "
+	help = "Because container layers are cached based on the RUN command string it "
 	       "will fail to include any changes to package version locks, etc... "
 	       "Use this flag to ensure a clean build."
 )
@@ -89,7 +89,7 @@ parser.add_argument(
 	dest = "updateVersions",
 	action = 'store_true',
 	help = "If set, will remove the package manager version locks prior to "
-	       "building the docker image to allow updated packages to be retrieved."
+	       "building the image to allow updated packages to be retrieved."
 )
 
 parser.add_argument(
@@ -120,7 +120,7 @@ imageTag = "{image}:{tag}".format( image = args.image, tag = args.tag )
 
 # 1. Versionlock management
 
-# As we can't have conditionals in the Dockerfile, we always copy in our
+# As we can't have conditionals in the Containerfile, we always copy in our
 # lock file, so to 'unlock' we simply empty it out so it has no effect.
 if args.updateVersions and not args.newPackagesOnly :
 	sys.stderr.write( "Unlocking all package versions...\n" )
@@ -130,7 +130,7 @@ if args.updateVersions and not args.newPackagesOnly :
 
 # 2. Build the image
 
-buildCommand = "docker build {cache} -t {tag} .".format(
+buildCommand = "podman build {cache} -t {tag} .".format(
 	cache = "--no-cache" if ( args.noCache or args.updateVersions ) else "",
 	tag = imageTag
 )
@@ -142,9 +142,9 @@ subprocess.check_call( buildCommand, shell = True )
 if args.updateVersions :
 	# Extract the updated version lock files from the container
 	extractCommand = " && ".join((
-		"docker create --name {name} {tag}",
-		"docker cp {name}:{versionlockSrc} {versionlockDest}",
-		"docker rm {name}",
+		"podman create --name {name} {tag}",
+		"podman cp {name}:{versionlockSrc} {versionlockDest}",
+		"podman rm {name}",
 		"sort {versionlockDest} -o {versionlockDest}"
 	)).format(
 		name = "gafferhq-build-{id}".format( id = uuid.uuid1() ),

--- a/build-docker.py
+++ b/build-docker.py
@@ -63,15 +63,6 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument(
-	"--upload",
-	action = 'store_true',
-	help = "Pushes the build image to dockerhub. You must first have used "
-	       "'docker login' to set your credentials. Obsolete, because we now "
-	       "use the GitHub Container Registry instead, with packages being "
-	       "uploaded automatically when we make a release."
-)
-
-parser.add_argument(
 	"--tag",
 	dest = "tag",
 	default = "latest",
@@ -124,7 +115,6 @@ args = parser.parse_args()
 #  1. Copy in versionlock list from source control or a blank one
 #  2. Perform build
 #  3. Copy out versionlock list if requested
-#  4. Upload final image to dockerhub
 
 imageTag = "{image}:{tag}".format( image = args.image, tag = args.tag )
 
@@ -164,10 +154,3 @@ if args.updateVersions :
 	)
 	sys.stderr.write( extractCommand + "\n" )
 	subprocess.check_call( extractCommand, shell = True )
-
-# 4. Upload
-
-if args.upload :
-	pushCommand = "docker push %s" % imageTag
-	sys.stderr.write( pushCommand + "\n" )
-	subprocess.check_call( pushCommand, shell = True )

--- a/build.py
+++ b/build.py
@@ -121,7 +121,7 @@ parser.add_argument(
 parser.add_argument(
 	"--container-image-version",
 	dest = "containerImageVersion",
-	default = "3.1.0",
+	default = "3.2.0",
 	help = "The image tag to use for container builds."
 )
 

--- a/yum-versionlock.list
+++ b/yum-versionlock.list
@@ -18,6 +18,7 @@ llvm-libs-0:17.0.6-3.module+el8.10.0+1869+0b51ffa4.*
 mesa-dri-drivers-0:23.1.4-3.el8_10.*
 mesa-filesystem-0:23.1.4-3.el8_10.*
 metacity-0:3.28.0-1.el8.*
+ncurses-compat-libs-0:6.1-10.20180224.el8.*
 rest-0:0.8.1-2.el8.*
 sound-theme-freedesktop-0:0.8-9.el8.*
 startup-notification-0:0.12-15.el8.*


### PR DESCRIPTION
This adds the `ncurses-compat-libs` needed to run RenderMan in our Rocky 8 container. It also reimplements `build-docker.py` to use `podman`, matching what we're using for the official builds on GitHub Actions.