### PR TITLE
Containerfile : Update to Cuda 12.8 and OptiX 8.0.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@
 - Containerfile :
   - Changed base image to `nvidia/cuda:12.8.0-devel-rockylinux8`.
   - Updated OptiX to 8.0.0.
+  - Added `sudo` [^1].
+
+[^1]: To be omitted from the notes for the final 4.0.0 release.
 
 4.0.0a1
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,9 @@
 4.x.x
 =====
 
-- Containerfile : Changed base image to `nvidia/cuda:12.8.0-devel-rockylinux8`.
+- Containerfile :
+  - Changed base image to `nvidia/cuda:12.8.0-devel-rockylinux8`.
+  - Updated OptiX to 8.0.0.
 
 4.0.0a1
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+4.x.x
+=====
+
+- Containerfile : Changed base image to `nvidia/cuda:12.8.0-devel-rockylinux8`.
+
 4.0.0a1
 =======
 

--- a/Containerfile
+++ b/Containerfile
@@ -119,9 +119,9 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 #
 # Install Optix headers for Cycles and OSL.
 #
-	mkdir /usr/local/NVIDIA-OptiX-SDK-7.3.0 && \
-	cd /usr/local/NVIDIA-OptiX-SDK-7.3.0 && \
-	curl -sL https://github.com/NVIDIA/optix-dev/archive/refs/tags/v7.3.0.tar.gz | tar -xz --strip-components=1 && \
+	mkdir /usr/local/NVIDIA-OptiX-SDK-8.0.0 && \
+	cd /usr/local/NVIDIA-OptiX-SDK-8.0.0 && \
+	curl -sL https://github.com/NVIDIA/optix-dev/archive/refs/tags/v8.0.0.tar.gz | tar -xz --strip-components=1 && \
 	cd - && \
 #
 # Install meson as it is needed to build LibEpoxy if building Cycles with USD support.
@@ -184,7 +184,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 ENV _INKSCAPE_GC="disable"
 
 # Make the Optix SDK and CUDA available to builds that require them.
-ENV OPTIX_ROOT_DIR=/usr/local/NVIDIA-OptiX-SDK-7.3.0
+ENV OPTIX_ROOT_DIR=/usr/local/NVIDIA-OptiX-SDK-8.0.0
 ENV CUDA_PATH=/usr/local/cuda-12.8
 
 # Enable the software collections we want by default, no matter how we enter the

--- a/Containerfile
+++ b/Containerfile
@@ -100,6 +100,7 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 # Note: When updating these, also update the MacOS setup in .github/workflows/main.yaml
 # (in GafferHQ/gaffer).
 	pip install \
+		setuptools==81.0.0 \
 		sphinx==4.3.1 \
 		sphinxcontrib-applehelp==1.0.4 \
 		sphinxcontrib-devhelp==1.0.2 \

--- a/Containerfile
+++ b/Containerfile
@@ -91,6 +91,12 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 		mesa-dri-drivers.x86_64 \
 		metacity \
 		gnome-themes-standard && \
+#
+# Install sudo as it's currently needed to
+# run Gaffer's test suite on CI.
+#
+	dnf install -y sudo && \
+#
 # Note: When updating these, also update the MacOS setup in .github/workflows/main.yaml
 # (in GafferHQ/gaffer).
 	pip install \

--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@
 # the glibc requirements of VFXPlatform 2023 (2.28 or lower), with some of our
 # build dependencies already pre-installed.
 
-FROM nvidia/cuda:11.8.0-devel-rockylinux8
+FROM nvidia/cuda:12.8.0-devel-rockylinux8
 
 # Identify the build environment. This can be used by build processes for
 # environment specific behaviour such as naming artifacts built from this
@@ -154,16 +154,17 @@ RUN yum install -y 'dnf-command(versionlock)' && \
 	rm -rf /usr/share/doc && \
 	dnf remove -y \
 		java-1.8.0-openjdk-headless \
-		cuda-nsight-compute-11-8.x86_64 \
-		libcublas-devel-11-8-11.11.3.6-1.x86_64 \
-		libcublas-11-8 libnccl libnccl-devel \
-		libnpp-11-8 libnpp-devel-11-8 cuda-cupti-11-8 && \
+		cuda-nsight-compute-12-8.x86_64 \
+		libcublas-12-8 libcublas-devel-12-8 \
+		libnccl libnccl-devel \
+		libnpp-12-8 libnpp-devel-12-8 \
+		cuda-cupti-12-8 cuda-compat-12-8 && \
 #
 # After trimming down CUDA, reinstall only the specific CUDA dependencies
 # required for OSL Optix builds.
 	dnf install -y \
-		cuda-nvrtc-devel-11-8 \
-		libcurand-devel-11-8 && \
+		cuda-nvrtc-devel-12-8 \
+		libcurand-devel-12-8 && \
 #
 # Now we've installed all our packages, update yum-versionlock for all the
 # new packages so we can copy the versionlock.list out of the container when we
@@ -184,7 +185,7 @@ ENV _INKSCAPE_GC="disable"
 
 # Make the Optix SDK and CUDA available to builds that require them.
 ENV OPTIX_ROOT_DIR=/usr/local/NVIDIA-OptiX-SDK-7.3.0
-ENV CUDA_PATH=/usr/local/cuda-11.8
+ENV CUDA_PATH=/usr/local/cuda-12.8
 
 # Enable the software collections we want by default, no matter how we enter the
 # container. For details, see :


### PR DESCRIPTION
This matches the versions used to build Cycles 5.0 in the Blender project and means we'll start producing sm_120 cubins that support Nvidia 50x0 GPUs. After a bit of extra optimisation, Cuda 12.8 is still 400MB larger than 11.8, though even so, with this increase we still come out 200MB smaller than our `build:3.4.0` container...